### PR TITLE
Test branch

### DIFF
--- a/base/leaderelection/leaderelection.py
+++ b/base/leaderelection/leaderelection.py
@@ -164,7 +164,8 @@ class LeaderElection:
 
         # If This candidate is not the leader and lease duration is yet to finish
         if (self.election_config.lock.identity != self.observed_record.holder_identity
-                and self.observed_time_milliseconds + self.election_config.lease_duration * 1000 > int(now_timestamp * 1000)):
+                and self.observed_time_milliseconds + self.election_config.lease_duration * 1000 >
+                int(now_timestamp * 1000)):
             logging.info("yet to finish lease_duration, lease held by {} and has not expired".format(old_election_record.holder_identity))
             return False
 

--- a/base/stream/stream.py
+++ b/base/stream/stream.py
@@ -32,7 +32,9 @@ def _websocket_request(websocket_request, force_kwargs, api_method, *args, **kwa
     prev_request = api_client.request
     binary = kwargs.pop('binary', False)
     try:
-        api_client.request = functools.partial(websocket_request, configuration, binary=binary)
+        api_client.request = functools.partial(websocket_request,
+                                               configuration,
+                                               binary=binary)
         out = api_method(*args, **kwargs)
         # The api_client insists on converting this to a string using its representation, so we have
         # to do this dance to strip it of the b' prefix and ' suffix, encode it byte-per-byte (latin1),


### PR DESCRIPTION
This PR focuses on improving code readability and maintainability within the `leaderelection` and `stream` modules by introducing strategic line breaks. These changes enhance code clarity without altering the underlying functionality.

Key changes:

*   **`base/leaderelection/leaderelection.py`**:  Improved the readability of a long conditional statement within the `try_acquire_or_renew` function. A line break was added to split the condition across multiple lines, making it easier to parse and understand the logic related to lease duration and leader identity. This change specifically targets the conditional that checks if the current candidate is not the leader and the lease duration has not yet expired.

*   **`base/stream/stream.py`**: Improved the readability of the `api_client.request` assignment within the `_websocket_request` function. Line breaks were added to the `functools.partial` call to improve the formatting and make the arguments passed to `websocket_request` more visible. This enhances the maintainability of the websocket stream functionality.

These changes aim to improve the overall code quality and maintainability of the codebase. No new dependencies or requirements are introduced by this PR. The changes are purely cosmetic and do not affect the runtime behavior of the application.

Reviewers should focus on confirming that the added line breaks do not introduce any unintended side effects (e.g., syntax errors) and that the code remains functionally equivalent to the previous version. Special attention should be given to ensuring that the line breaks in the conditional statement in `leaderelection.py` do not alter the intended logic.